### PR TITLE
Corrected location of lcov.info in codeclimate script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "jshint": "jshint .",
     "start": "node server.js",
     "nodemon": "nodemon server.js",
-    "codeclimate": "CODECLIMATE_REPO_TOKEN=ea5c19d8d1385dea0fda29fec82bcd4268b999056e764d533bb33f836dd16743 codeclimate-test-reporter < lcov.info"
+    "codeclimate": "CODECLIMATE_REPO_TOKEN=ea5c19d8d1385dea0fda29fec82bcd4268b999056e764d533bb33f836dd16743 codeclimate-test-reporter < ./coverage/lcov.info"
   },
   "repository": {
     "type": "git",
@@ -44,6 +44,7 @@
   },
   "pre-commit": [
     "jshint",
-    "coverage"
+    "coverage",
+    "codeclimate"
   ]
 }


### PR DESCRIPTION
I _think_ that the problem was our lcov.info wasn't being found so now should be correctly sent to codeclimate and maybe our badge will now tell us what our coverage is!
